### PR TITLE
Add alternative word sets

### DIFF
--- a/BabyKeyboardLock/EventEffectHandler.swift
+++ b/BabyKeyboardLock/EventEffectHandler.swift
@@ -275,7 +275,7 @@ class EventEffectHandler {
         "zebra": "斑马", "zip": "拉链", "zap": "啪", "zig": "锯齿", "zoo": "动物园", "zen": "禅", "zero": "零", "zone": "区域"
     ]
     
-    private var wordSetType: WordSetType = .standard
+    private var wordSetType: WordSetType = .randomShortWords
     private let customWordSetsManager = CustomWordSetsManager.shared
     
     private let synthesizer = NSSpeechSynthesizer()

--- a/BabyKeyboardLock/EventHandler.swift
+++ b/BabyKeyboardLock/EventHandler.swift
@@ -35,7 +35,7 @@ class EventHandler: ObservableObject {
             eventEffectHandler.translationLanguage = selectedTranslationLanguage
         }
     }
-    @Published var selectedWordSetType: WordSetType = .standard {
+    @Published var selectedWordSetType: WordSetType = .randomShortWords {
         didSet {
             eventEffectHandler.setWordSetType(selectedWordSetType)
         }

--- a/BabyKeyboardLock/Localizable.xcstrings
+++ b/BabyKeyboardLock/Localizable.xcstrings
@@ -46,6 +46,15 @@
         }
       }
     },
+    "Cancel" : {
+
+    },
+    "Contains %lld words" : {
+
+    },
+    "Edit the words used in 'Main Words' set" : {
+
+    },
     "Effect" : {
       "localizations" : {
         "de" : {
@@ -67,6 +76,9 @@
           }
         }
       }
+    },
+    "English word" : {
+
     },
     "Firework window" : {
       "extractionState" : "stale",
@@ -257,6 +269,12 @@
         }
       }
     },
+    "Main words" : {
+
+    },
+    "Main Words" : {
+
+    },
     "Quit %@" : {
       "localizations" : {
         "de" : {
@@ -279,28 +297,8 @@
         }
       }
     },
-    "unlock_shortcut_hint" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sie können die Tastenkombination Strg + Wahltaste + U verwenden, um die Tastatursperre umzuschalten."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You can use shortcut Ctrl + Option + U to toggle keyboard lock"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你可以用快捷键 Ctrl + Option + U 来切换键盘锁定"
-          }
-        }
-      }
+    "Save" : {
+
     },
     "Translation" : {
       "localizations" : {
@@ -324,25 +322,25 @@
         }
       }
     },
-    "TranslationLanguage.none" : {
+    "TranslationLanguage.chinese" : {
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Keine Übersetzung"
+            "value" : "Chinesisch"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No translation"
+            "value" : "Chinese"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不翻译"
+            "value" : "中文"
           }
         }
       }
@@ -393,52 +391,6 @@
         }
       }
     },
-    "TranslationLanguage.russian" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Russisch"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Russian"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "俄语"
-          }
-        }
-      }
-    },
-    "TranslationLanguage.spanish" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spanisch"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spanish"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "西班牙语"
-          }
-        }
-      }
-    },
     "TranslationLanguage.italian" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -485,25 +437,119 @@
         }
       }
     },
-    "TranslationLanguage.chinese" : {
+    "TranslationLanguage.none" : {
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Chinesisch"
+            "value" : "Keine Übersetzung"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Chinese"
+            "value" : "No translation"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "中文"
+            "value" : "不翻译"
+          }
+        }
+      }
+    },
+    "TranslationLanguage.russian" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Russisch"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Russian"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "俄语"
+          }
+        }
+      }
+    },
+    "TranslationLanguage.spanish" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spanisch"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spanish"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "西班牙语"
+          }
+        }
+      }
+    },
+    "unlock_shortcut_hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie können die Tastenkombination Strg + Wahltaste + U verwenden, um die Tastatursperre umzuschalten."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can use shortcut Ctrl + Option + U to toggle keyboard lock"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你可以用快捷键 Ctrl + Option + U 来切换键盘锁定"
+          }
+        }
+      }
+    },
+    "Word Set" : {
+
+    },
+    "WordSetType.mainWords" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Main Words"
+          }
+        }
+      }
+    },
+    "WordSetType.standard" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standard"
           }
         }
       }

--- a/BabyKeyboardLock/Localizable.xcstrings
+++ b/BabyKeyboardLock/Localizable.xcstrings
@@ -532,8 +532,17 @@
     "Word Set" : {
 
     },
+    "WordSetType.randomShortWords" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Random short words"
+          }
+        }
+      }
+    },
     "WordSetType.mainWords" : {
-      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/BabyKeyboardLock/LockEffect.swift
+++ b/BabyKeyboardLock/LockEffect.swift
@@ -63,7 +63,7 @@ enum TranslationLanguage: String, CaseIterable, Identifiable {
 }
 
 enum WordSetType: String, CaseIterable, Identifiable {
-    case standard = "WordSetType.standard"
+    case randomShortWords = "WordSetType.randomShortWords"
     case mainWords = "WordSetType.mainWords"
     
     var id: Self {

--- a/BabyKeyboardLock/LockEffect.swift
+++ b/BabyKeyboardLock/LockEffect.swift
@@ -62,3 +62,16 @@ enum TranslationLanguage: String, CaseIterable, Identifiable {
     }
 }
 
+enum WordSetType: String, CaseIterable, Identifiable {
+    case standard = "WordSetType.standard"
+    case mainWords = "WordSetType.mainWords"
+    
+    var id: Self {
+        return self
+    }
+    
+    var localizedString: String {
+        NSLocalizedString(self.rawValue, comment: "Word set type option")
+    }
+}
+

--- a/BabyKeyboardLock/utils/CustomWordSet.swift
+++ b/BabyKeyboardLock/utils/CustomWordSet.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Combine
+
+struct CustomWordPair: Codable, Hashable, Identifiable {
+    var id = UUID()
+    let english: String
+    let translation: String
+}
+
+struct CustomWordSet: Codable, Hashable, Identifiable {
+    var id = UUID()
+    let name: String
+    let words: [CustomWordPair]
+}
+
+class CustomWordSetsManager: ObservableObject {
+    static let shared = CustomWordSetsManager()
+    
+    @Published var wordSets: [CustomWordSet] = []
+    @Published var selectedWordSetIndex: Int = 0
+    
+    private let userDefaultsKey = "customWordSets"
+    
+    init() {
+        loadWordSets()
+        // Add default "Main Words" set if no sets exist
+        if wordSets.isEmpty {
+            let mainWords = [
+                CustomWordPair(english: "mama", translation: "мама"),
+                CustomWordPair(english: "papa", translation: "папа"),
+                CustomWordPair(english: "arm", translation: "рука"),
+                CustomWordPair(english: "leg", translation: "нога"),
+                CustomWordPair(english: "nose", translation: "нос"),
+                CustomWordPair(english: "eye", translation: "глаз"),
+                
+                CustomWordPair(english: "apple", translation: "яблоко"),
+                CustomWordPair(english: "ball", translation: "мяч"),
+                CustomWordPair(english: "cat", translation: "кот"),
+                CustomWordPair(english: "dog", translation: "собака"),
+                CustomWordPair(english: "elephant", translation: "слон"),
+                CustomWordPair(english: "fish", translation: "рыба"),
+                CustomWordPair(english: "goat", translation: "коза"),
+                CustomWordPair(english: "house", translation: "дом"),
+                CustomWordPair(english: "ice", translation: "лёд"),
+                CustomWordPair(english: "jump", translation: "прыгать"),
+                CustomWordPair(english: "kite", translation: "воздушный змей"),
+                CustomWordPair(english: "lion", translation: "лев"),
+                CustomWordPair(english: "moon", translation: "луна"),
+                CustomWordPair(english: "night", translation: "ночь"),
+                CustomWordPair(english: "orange", translation: "апельсин"),
+                CustomWordPair(english: "pen", translation: "ручка"),
+                CustomWordPair(english: "queen", translation: "королева"),
+                CustomWordPair(english: "rabbit", translation: "кролик"),
+                CustomWordPair(english: "sun", translation: "солнце"),
+                CustomWordPair(english: "tree", translation: "дерево"),
+                CustomWordPair(english: "umbrella", translation: "зонт"),
+                CustomWordPair(english: "vase", translation: "ваза"),
+                CustomWordPair(english: "water", translation: "вода"),
+                CustomWordPair(english: "xylophone", translation: "ксилофон"),
+                CustomWordPair(english: "yellow", translation: "жёлтый"),
+                CustomWordPair(english: "zebra", translation: "зебра")
+            ]
+            wordSets = [CustomWordSet(name: "Main Words", words: mainWords)]
+            saveWordSets()
+        }
+    }
+    
+    var currentWordSet: CustomWordSet? {
+        guard !wordSets.isEmpty else {
+            return nil
+        }
+        return wordSets[0] // Always use the first word set as "Main Words"
+    }
+    
+    func getWordMap() -> [String: [String]] {
+        guard let currentSet = currentWordSet else {
+            return [:]
+        }
+        
+        var wordMap: [String: [String]] = [:]
+        
+        for word in currentSet.words {
+            let firstLetter = String(word.english.prefix(1).lowercased())
+            if wordMap[firstLetter] == nil {
+                wordMap[firstLetter] = []
+            }
+            wordMap[firstLetter]?.append(word.english)
+        }
+        
+        return wordMap
+    }
+    
+    func getTranslation(for word: String) -> String? {
+        guard let currentSet = currentWordSet else {
+            return nil
+        }
+        
+        return currentSet.words.first(where: { $0.english.lowercased() == word.lowercased() })?.translation
+    }
+    
+    func updateMainWords(words: [CustomWordPair]) {
+        if wordSets.isEmpty {
+            wordSets = [CustomWordSet(name: "Main Words", words: words)]
+        } else {
+            wordSets[0] = CustomWordSet(name: "Main Words", words: words)
+        }
+        saveWordSets()
+        objectWillChange.send()
+        NotificationCenter.default.post(name: .init("MainWordsUpdated"), object: nil)
+    }
+    
+    private func saveWordSets() {
+        if let encoded = try? JSONEncoder().encode(wordSets) {
+            UserDefaults.standard.set(encoded, forKey: userDefaultsKey)
+        }
+    }
+    
+    private func loadWordSets() {
+        if let savedSets = UserDefaults.standard.data(forKey: userDefaultsKey),
+           let decodedSets = try? JSONDecoder().decode([CustomWordSet].self, from: savedSets) {
+            wordSets = decodedSets
+        }
+    }
+} 

--- a/BabyKeyboardLock/views/ContentView.swift
+++ b/BabyKeyboardLock/views/ContentView.swift
@@ -35,7 +35,7 @@ struct ContentView: View {
     @AppStorage("lockKeyboardOnLaunch") private var lockKeyboardOnLaunch: Bool = false
     @AppStorage("selectedLockEffect") var selectedLockEffect: LockEffect = .none
     @AppStorage("selectedTranslationLanguage") var selectedTranslationLanguage: TranslationLanguage = .none
-    @AppStorage("selectedWordSetType") var savedWordSetType: String = WordSetType.standard.rawValue
+    @AppStorage("selectedWordSetType") var savedWordSetType: String = WordSetType.randomShortWords.rawValue
     
     @State private var showWordSetEditor = false
     @StateObject private var customWordSetsManager = CustomWordSetsManager.shared


### PR DESCRIPTION
This PR adds support for custom word sets in the "Speak a Key Word" mode:

  - Introduces a new "Main Words" word set option alongside the standard set
  - Adds a word set editor to create and manage custom word sets
  - Supports word set persistence with AppStorage